### PR TITLE
Introduce import.meta.hot

### DIFF
--- a/src/internal/runtime/createBrowserRuntime/createBrowserSystem.js
+++ b/src/internal/runtime/createBrowserRuntime/createBrowserSystem.js
@@ -64,6 +64,19 @@ export const createBrowserSystem = ({
     return {
       url: importerUrl,
       resolve: (specifier) => resolve(specifier, importerUrl),
+      // https://github.com/pikapkg/esm-hmr
+      // https://github.com/systemjs/systemjs/pull/2014
+      hot: {
+        accept: (deps, handler) => {
+          if (typeof deps === "function") {
+            handler = deps
+            deps = []
+          }
+        },
+        dispose: () => {},
+        decline: () => {},
+        invalidate: () => {},
+      },
     }
   }
 


### PR DESCRIPTION
Ideally jsenv should be able to provide import.meta.hot to allow hot module replacement.

HMR downsides:
- There is not yet a real need for this (livereload being fast + selective css loading is enough for now).
- have to put `import.meta.hot.accept` everywhere
- complexify jsenv codebase
- need to investigate what is this module object passed down to import.meta.accept and sync with systemjs to have it.

For now this pr is kept as draft, especially until there is a real need to hot module replacement.