### PR TITLE
Update async_to_promises to avoid second babel transformation

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@jsenv/package-publish": "1.6.2",
     "@jsenv/performance-impact": "2.2.1",
     "@jsenv/pwa": "4.0.0",
-    "babel-plugin-transform-async-to-promises": "0.8.16",
+    "babel-plugin-transform-async-to-promises": "0.8.17",
     "eslint": "7.32.0",
     "eslint-plugin-html": "6.2.0",
     "eslint-plugin-import": "2.25.3",

--- a/packages/jsenv-babel-preset/jsenv_babel_preset.cjs
+++ b/packages/jsenv-babel-preset/jsenv_babel_preset.cjs
@@ -34,17 +34,24 @@ module.exports = (
     require("@babel/plugin-proposal-optional-catch-binding"),
     require("@babel/plugin-proposal-optional-chaining"),
     require("@babel/plugin-proposal-unicode-property-regex"),
-    (...args) => {
-      // enforce babel-plugin-transform-async-to-promises to return a name
-      // so that when jsenv uses loadOptionsFromFile it can know which babel plugin
-      // we are talking about
-      const transformAsyncToPromisesFactory = require("babel-plugin-transform-async-to-promises")
-      const transformAsyncToPromises = transformAsyncToPromisesFactory(...args)
-      return {
-        name: "transform-async-to-promises",
-        ...transformAsyncToPromises,
-      }
-    },
+    [
+      (...args) => {
+        // enforce babel-plugin-transform-async-to-promises to return a name
+        // so that when jsenv uses loadOptionsFromFile it can know which babel plugin
+        // we are talking about
+        const transformAsyncToPromisesFactory = require("babel-plugin-transform-async-to-promises")
+        const transformAsyncToPromises = transformAsyncToPromisesFactory(
+          ...args,
+        )
+        return {
+          name: "transform-async-to-promises",
+          ...transformAsyncToPromises,
+        }
+      },
+      {
+        topLevelAwait: "simple",
+      },
+    ],
     require("@babel/plugin-transform-arrow-functions"),
     require("@babel/plugin-transform-block-scoped-functions"),
     require("@babel/plugin-transform-block-scoping"),

--- a/packages/jsenv-babel-preset/package.json
+++ b/packages/jsenv-babel-preset/package.json
@@ -51,7 +51,7 @@
     "@babel/plugin-transform-template-literals": "7.16.5",
     "@babel/plugin-transform-typeof-symbol": "7.16.5",
     "@babel/plugin-transform-unicode-regex": "7.16.5",
-    "babel-plugin-transform-async-to-promises": "0.8.15"
+    "babel-plugin-transform-async-to-promises": "0.8.17"
   },
   "devDependencies": {}
 }

--- a/src/buildProject.js
+++ b/src/buildProject.js
@@ -41,7 +41,6 @@ export const buildProject = async ({
   format === "esmodule"
     ? jsenvBrowserRuntimeSupport
     : jsenvNodeRuntimeSupport,
-  transformTopLevelAwait = true,
 
   urlMappings = {},
   importResolutionMethod = format === "commonjs" ? "node" : "importmap",
@@ -163,8 +162,9 @@ export const buildProject = async ({
     // that is expecting esmodule format, not systemjs
     outDirectoryName: "build",
     importDefaultExtension,
-    moduleOutFormat: "esmodule", // rollup or jsenv rollup plugin will transform into the right format
-    importMetaFormat: "esmodule", // rollup or jsenv rollup plugin will transform into the right format
+    moduleOutFormat: "esmodule", // rollup will transform into the right format
+    importMetaFormat: "esmodule", // rollup will transform into the right format
+    topLevelAwait: "ignore", // rollup will transform if needed
 
     protocol,
     privateKey,
@@ -173,7 +173,6 @@ export const buildProject = async ({
     port,
     env,
     babelPluginMap,
-    transformTopLevelAwait,
     customCompilers,
     runtimeSupport,
 
@@ -220,7 +219,6 @@ export const buildProject = async ({
       globalName,
       globals,
       babelPluginMap: compileServer.babelPluginMap,
-      transformTopLevelAwait,
       runtimeSupport,
 
       urlVersioning,

--- a/src/internal/building/buildUsingRollup.js
+++ b/src/internal/building/buildUsingRollup.js
@@ -38,7 +38,6 @@ export const buildUsingRollup = async ({
   globals,
   babelPluginMap,
   runtimeSupport,
-  transformTopLevelAwait,
 
   urlMappings,
   importResolutionMethod,
@@ -108,7 +107,6 @@ export const buildUsingRollup = async ({
     format,
     systemJsUrl,
     babelPluginMap,
-    transformTopLevelAwait,
     node,
     browser,
     importAssertionsSupport,

--- a/src/internal/building/rollup_plugin_jsenv.js
+++ b/src/internal/building/rollup_plugin_jsenv.js
@@ -240,9 +240,10 @@ export const createRollupPlugins = async ({
   let minifyHtml
 
   const rollupPlugins = []
-  // rollup add async/await that might be unsupported by the runtime
+  // When format is systemjs, rollup add async/await
+  // that might be unsupported by the runtime.
   // in that case we have to transform the rollup output
-  if (babelPluginMap["transform-async-to-promises"]) {
+  if (babelPluginMap["transform-async-to-promises"] && format === "systemjs") {
     rollupPlugins.push({
       name: "jsenv_fix_async_await",
       async renderChunk(code, chunk) {
@@ -257,10 +258,9 @@ export const createRollupPlugins = async ({
             "transform-async-to-promises":
               babelPluginMap["transform-async-to-promises"],
           },
-          moduleOutFormat:
-            // pass undefined when format is "systemjs" to avoid
-            // re-wrapping the code in systemjs format
-            format === "systemjs" ? undefined : format,
+          // pass undefined when format is "systemjs" to avoid
+          // re-wrapping the code in systemjs format
+          moduleOutFormat: undefined,
           babelHelpersInjectionAsImport: false,
           transformGenerator: false,
         })

--- a/src/internal/building/rollup_plugin_jsenv.js
+++ b/src/internal/building/rollup_plugin_jsenv.js
@@ -257,12 +257,12 @@ export const createRollupPlugins = async ({
             "transform-async-to-promises":
               babelPluginMap["transform-async-to-promises"],
           },
-          babelHelpersInjectionAsImport: false,
-          transformGenerator: false,
           moduleOutFormat:
             // pass undefined when format is "systemjs" to avoid
             // re-wrapping the code in systemjs format
             format === "systemjs" ? undefined : format,
+          babelHelpersInjectionAsImport: false,
+          transformGenerator: false,
         })
         code = result.code
         map = result.map

--- a/src/internal/building/url_loader.js
+++ b/src/internal/building/url_loader.js
@@ -119,6 +119,9 @@ export const createUrlLoader = ({
         projectDirectoryUrl,
         babelPluginMap,
         // moduleOutFormat: format // we are compiling for rollup output must be "esmodule"
+        // we compile for rollup, let top level await untouched
+        // it will be converted, if needed, during "renderChunk" hook
+        topLevelAwait: "ignore",
       })
       let code = transformResult.code
       let map = transformResult.map

--- a/src/internal/compiling/createCompiledFileService.js
+++ b/src/internal/compiling/createCompiledFileService.js
@@ -41,10 +41,10 @@ export const createCompiledFileService = ({
   outDirectoryRelativeUrl,
 
   runtimeSupport,
-  transformTopLevelAwait,
+  babelPluginMap,
   moduleOutFormat,
   importMetaFormat,
-  babelPluginMap,
+  topLevelAwait,
   groupMap,
   customCompilers,
 
@@ -185,16 +185,16 @@ export const createCompiledFileService = ({
           request,
 
           runtimeSupport,
+          babelPluginMap: babelPluginMapFromCompileId(compileId, {
+            babelPluginMap,
+            groupMap,
+          }),
           moduleOutFormat:
             moduleOutFormat === undefined
               ? compileIdModuleFormats[compileId]
               : moduleOutFormat,
           importMetaFormat,
-          transformTopLevelAwait,
-          babelPluginMap: babelPluginMapFromCompileId(compileId, {
-            babelPluginMap,
-            groupMap,
-          }),
+          topLevelAwait,
 
           sourcemapMethod,
           sourcemapExcludeSources,

--- a/src/internal/compiling/js-compilation-service/findAsyncPluginNameInBabelPluginMap.js
+++ b/src/internal/compiling/js-compilation-service/findAsyncPluginNameInBabelPluginMap.js
@@ -1,9 +1,0 @@
-export const findAsyncPluginNameInBabelPluginMap = (babelPluginMap) => {
-  if ("transform-async-to-promises" in babelPluginMap) {
-    return "transform-async-to-promises"
-  }
-  if ("transform-async-to-generator" in babelPluginMap) {
-    return "transform-async-to-generator"
-  }
-  return ""
-}

--- a/src/internal/compiling/js-compilation-service/jsenvTransform.js
+++ b/src/internal/compiling/js-compilation-service/jsenvTransform.js
@@ -23,9 +23,9 @@ export const jsenvTransform = async ({
   babelPluginMap,
   moduleOutFormat,
   importMetaFormat = moduleOutFormat,
+  topLevelAwait,
 
   babelHelpersInjectionAsImport,
-  allowTopLevelAwait,
   transformGenerator,
   regeneratorRuntimeImportPath,
   sourcemapEnabled,
@@ -47,7 +47,11 @@ export const jsenvTransform = async ({
     sourceFileName: inputPath,
     // https://babeljs.io/docs/en/options#parseropts
     parserOpts: {
-      allowAwaitOutsideFunction: allowTopLevelAwait,
+      allowAwaitOutsideFunction:
+        topLevelAwait === undefined ||
+        topLevelAwait === "return" ||
+        topLevelAwait === "simple" ||
+        topLevelAwait === "ignore",
     },
     generatorOpts: {
       compact: false,
@@ -144,12 +148,9 @@ export const jsenvTransform = async ({
     "import-metadata": [babelPluginImportMetadata],
   }
 
-  if (allowTopLevelAwait) {
-    const asyncToPromise = babelPluginMap["transform-async-to-promises"]
-    if (asyncToPromise) {
-      asyncToPromise.options.topLevelAwait =
-        moduleOutFormat === "systemjs" ? "return" : "simple"
-    }
+  const asyncToPromise = babelPluginMap["transform-async-to-promises"]
+  if (topLevelAwait && asyncToPromise) {
+    asyncToPromise.options.topLevelAwait = topLevelAwait
   }
 
   const babelTransformReturnValue = await babelTransform({

--- a/src/internal/compiling/js-compilation-service/transformJs.js
+++ b/src/internal/compiling/js-compilation-service/transformJs.js
@@ -12,8 +12,7 @@ export const transformJs = async ({
   moduleOutFormat = "esmodule",
   importMetaFormat = moduleOutFormat,
   babelHelpersInjectionAsImport = moduleOutFormat === "esmodule",
-  allowTopLevelAwait = true,
-  transformTopLevelAwait = true,
+  topLevelAwait,
   transformGenerator = true,
   sourcemapEnabled = true,
 }) => {
@@ -52,8 +51,7 @@ export const transformJs = async ({
     importMetaFormat,
 
     babelHelpersInjectionAsImport,
-    allowTopLevelAwait,
-    transformTopLevelAwait,
+    topLevelAwait,
     transformGenerator,
     sourcemapEnabled,
   })

--- a/src/internal/compiling/jsenvCompilerForHtml.js
+++ b/src/internal/compiling/jsenvCompilerForHtml.js
@@ -42,10 +42,10 @@ export const compileHtml = async ({
   outDirectoryRelativeUrl,
   compileId,
 
-  transformTopLevelAwait,
+  babelPluginMap,
   moduleOutFormat,
   importMetaFormat,
-  babelPluginMap,
+  topLevelAwait,
 
   sourcemapMethod,
 
@@ -284,10 +284,10 @@ export const compileHtml = async ({
           compiledUrl: scriptCompiledFileUrl,
           projectDirectoryUrl,
 
-          transformTopLevelAwait,
+          babelPluginMap,
           moduleOutFormat,
           importMetaFormat,
-          babelPluginMap,
+          topLevelAwait,
         })
       } catch (e) {
         // If there is a syntax error in inline script

--- a/src/internal/compiling/jsenvCompilerForJavaScript.js
+++ b/src/internal/compiling/jsenvCompilerForJavaScript.js
@@ -9,9 +9,9 @@ export const compileJavascript = async ({
   projectDirectoryUrl,
 
   babelPluginMap,
-  transformTopLevelAwait,
   moduleOutFormat,
   importMetaFormat,
+  topLevelAwait,
 
   sourcemapExcludeSources,
   sourcemapMethod,
@@ -24,9 +24,9 @@ export const compileJavascript = async ({
     projectDirectoryUrl,
 
     babelPluginMap,
-    transformTopLevelAwait,
     moduleOutFormat,
     importMetaFormat,
+    topLevelAwait,
   })
 
   return transformResultToCompilationResult(

--- a/src/internal/compiling/startCompileServer.js
+++ b/src/internal/compiling/startCompileServer.js
@@ -82,9 +82,9 @@ export const startCompileServer = async ({
   projectFileCacheStrategy = "mtime",
 
   // js compile options
-  transformTopLevelAwait = true,
   moduleOutFormat,
   importMetaFormat,
+  topLevelAwait,
   env = {},
   processEnvNodeEnv = process.env.NODE_ENV,
   replaceProcessEnvNodeEnv = true,
@@ -310,7 +310,7 @@ export const startCompileServer = async ({
       importDefaultExtension,
 
       runtimeSupport,
-      transformTopLevelAwait,
+      topLevelAwait,
       groupMap: compileServerGroupMap,
       babelPluginMap,
       customCompilers,

--- a/test/building/override_importmap/override_importmap_build.test.js
+++ b/test/building/override_importmap/override_importmap_build.test.js
@@ -36,7 +36,7 @@ const { buildMappings } = await buildProject({
   const actual = buildMappings
   const expected = {
     // the importmap is not in buildMappings as it was inlined by the build
-    [`${testDirectoryRelativeUrl}main.js`]: "main-2e94c91c.js",
+    [`${testDirectoryRelativeUrl}main.js`]: "main-ca955363.js",
     [`${testDirectoryRelativeUrl}override_importmap.html`]: "main.html",
   }
   assert({ actual, expected })

--- a/test/building/without_js_concatenation/without_js_concatenation_build.test.js
+++ b/test/building/without_js_concatenation/without_js_concatenation_build.test.js
@@ -33,8 +33,8 @@ const { buildMappings } = await buildProject({
 {
   const actual = buildMappings
   const expected = {
-    [`${testDirectoryRelativeUrl}file.js`]: "file-1f0c7cdd.js",
-    [`${testDirectoryRelativeUrl}main.js`]: "main-fd6b03f3.js",
+    [`${testDirectoryRelativeUrl}file.js`]: "file-d4d10f0c.js",
+    [`${testDirectoryRelativeUrl}main.js`]: "main-a10d6b06.js",
     [`${testDirectoryRelativeUrl}without_js_concatenation.html`]: "main.html",
   }
   assert({ actual, expected })

--- a/test/force_inline/script_module_force_inline/script_module_force_inline_build.test.js
+++ b/test/force_inline/script_module_force_inline/script_module_force_inline_build.test.js
@@ -43,11 +43,11 @@ const { buildManifest, buildFileContents, buildInlineFileContents } =
       "main.html": "main.html",
     },
     buildFileContents: {
-      "file-73d04a60.js.map": assert.any(String),
+      "file-02c226c4.js.map": assert.any(String),
       "main.html": assert.any(String),
     },
     buildInlineFileContents: {
-      "file-73d04a60.js": assert.any(String),
+      "file-02c226c4.js": assert.any(String),
     },
   }
   assert({ actual, expected })
@@ -87,12 +87,13 @@ const htmlString = await readFile(htmlBuildUrl)
     srcAttribute: undefined,
     forceInlineAttribute: undefined,
     textNodeValue: `// eslint-disable-next-line import/no-unresolved
+
 {
   var answer = 42;
   console.log(answer);
 }
 
-//# sourceMappingURL=file-73d04a60.js.map`,
+//# sourceMappingURL=file-02c226c4.js.map`,
   }
   assert({ actual, expected })
 }

--- a/test/sourcemap_build_commonjs/sourcemap_build_commonjs.test.js
+++ b/test/sourcemap_build_commonjs/sourcemap_build_commonjs.test.js
@@ -46,7 +46,7 @@ const compilationResult = buildToCompilationResult(build, {
 const sourceMap = JSON.parse(compilationResult.assetsContent[0])
 const sourceMapConsumer = await new SourceMapConsumer(sourceMap)
 const actual = sourceMapConsumer.originalPositionFor({
-  line: 8,
+  line: 6,
   column: 0,
   bias: 2,
 })

--- a/test/workers/workers_build.test.js
+++ b/test/workers/workers_build.test.js
@@ -59,7 +59,7 @@ if (process.platform !== "win32") {
           // To ensure worker is still updated, jsenv adds a jsenvStaticUrlsHash
           // to include a hash for the html file.
           // -> when html file changes -> hash changes -> worker updates
-          version: "a49d1fe5",
+          version: "03c933a5",
         },
         "assets/style-b126d686.css": {
           versioned: true,


### PR DESCRIPTION
Update transform-async-to-promises babel plugin. This should allow to perform babel transform once.

See https://github.com/rpetrich/babel-plugin-transform-async-to-promises/issues/26

## Problems so far

### Rollup syntax error

```console
SyntaxError: 'import' and 'export' may only appear at the top level (18:2)
```

Rollup is not happy because
```js
const { value } = await import("./dependency.js")

export { answer }
```

Is transformed into 

```js
function _await(value, then, direct) {
  if (direct) {
    return then ? then(value) : value;
  }

  if (!value || !value.then) {
    value = Promise.resolve(value);
  }

  return then ? value.then(then) : value;
}

_await(import("./dependency.js"), function (_await$import) {
  var value = _await$import.value;
  export { value };
});
```

The previous version of async-to-promises output the following:

```js
var _await$import = await import("./dependency.js"),
    value = _await$import.value;

export { value }
```

Fix to try: Disable top level await transformation as it will be handled by rollup. I need a topLevelAwait: 'ignore' options to be able to try this.

## Babel syntax error

```console
Property declaration of ExportNamedDeclaration expected 
node to be of a type ["Declaration"] but instead got "EmptyStatement"
```

Seems to happen when a file uses both transform-async-to-promises + transform-react-jsx and contains a top level await