### PR TITLE
Compile id hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsenv/core",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "description": "Tool to develop, test and build js projects",
   "license": "MIT",
   "repository": {

--- a/src/internal/compile_server/compile_file.js
+++ b/src/internal/compile_server/compile_file.js
@@ -14,6 +14,7 @@ export const compileFile = async ({
   logger,
 
   projectDirectoryUrl,
+  jsenvDirectory,
   jsenvRemoteDirectory,
   originalFileUrl,
   compiledFileUrl,
@@ -103,6 +104,7 @@ export const compileFile = async ({
       // when serving sourcemap files
       await updateCompileCache({
         logger,
+        jsenvDirectory,
         meta,
         compileResult,
         compileResultStatus,

--- a/src/internal/compile_server/compiled_file_service.js
+++ b/src/internal/compile_server/compiled_file_service.js
@@ -138,6 +138,7 @@ export const createCompiledFileService = ({
       logger,
 
       projectDirectoryUrl,
+      jsenvDirectory,
       jsenvRemoteDirectory,
       originalFileUrl,
       compiledFileUrl,

--- a/src/internal/compile_server/jsenv_directory/jsenv_directory.js
+++ b/src/internal/compile_server/jsenv_directory/jsenv_directory.js
@@ -88,7 +88,7 @@ export const setupJsenvDirectory = async ({
       }
       return existingCompileId
     }
-    const compileIdBase = generateCompileId({ compileProfile })
+    const compileIdBase = generateCompileId({ compileProfile, runtime })
     let compileId = compileIdBase
     let integer = 1
     while (existingCompileIds.includes(compileId)) {
@@ -109,9 +109,15 @@ export const setupJsenvDirectory = async ({
   }
 }
 
-const generateCompileId = ({ compileProfile }) => {
+const generateCompileId = ({ compileProfile, runtime }) => {
+  if (runtime.name === "jsenv_build") {
+    return `out_build`
+  }
   if (compileProfile.missingFeatures["transform-instrument"]) {
     return `out_instrumented`
+  }
+  if (compileProfile.moduleOutFormat === "systemjs") {
+    return `out_system`
   }
   return `out`
 }

--- a/src/internal/compile_server/jsenv_directory/update_compile_cache.js
+++ b/src/internal/compile_server/jsenv_directory/update_compile_cache.js
@@ -10,6 +10,7 @@ import { getMetaJsonFileUrl } from "./compile_asset.js"
 
 export const updateCompileCache = async ({
   logger,
+  jsenvDirectory,
   meta,
   compiledFileUrl,
   compileResult,
@@ -17,6 +18,9 @@ export const updateCompileCache = async ({
 }) => {
   const isNew = compileResultStatus === "created"
   const isUpdated = compileResultStatus === "updated"
+  if (!isNew && !isUpdated) {
+    return
+  }
   const {
     compiledSource,
     contentType,
@@ -26,125 +30,102 @@ export const updateCompileCache = async ({
     assetsContent,
     dependencies,
   } = compileResult
-
   const promises = []
-  if (isNew || isUpdated) {
-    // ensure source that does not leads to concrete files are not capable to invalidate the cache
-    const sourcesToRemove = sources.filter((sourceFileUrl) => {
-      return (
-        sourceFileUrl.startsWith("file://") && !testFilePresence(sourceFileUrl)
-      )
-    })
-    const sourceNotFoundCount = sourcesToRemove.length
-    if (sourceNotFoundCount > 0) {
-      logger.warn(`SOURCE_META_NOT_FOUND: ${sourceNotFoundCount} source file(s) not found.
+  // ensure source that does not leads to concrete files are not capable to invalidate the cache
+  const sourcesToRemove = sources.filter((sourceFileUrl) => {
+    return (
+      sourceFileUrl.startsWith("file://") && !testFilePresence(sourceFileUrl)
+    )
+  })
+  const sourceNotFoundCount = sourcesToRemove.length
+  if (sourceNotFoundCount > 0) {
+    logger.warn(`SOURCE_META_NOT_FOUND: ${sourceNotFoundCount} source file(s) not found.
 --- consequence ---
 cache will be reused even if one of the source file is modified
 --- source files not found ---
 ${sourcesToRemove.join(`\n`)}`)
-      sourcesToRemove.forEach((url) => {
-        const sourceIndex = sources.indexOf(url)
-        if (sourceIndex) {
-          sources.splice(sourceIndex, 1)
-          sourcesContent.splice(sourceIndex, 1)
-        }
-      })
-    }
-
-    const { writeCompiledSourceFile = true, writeAssetsFile = true } =
-      compileResult
-
-    if (writeCompiledSourceFile) {
-      logger.debug(
-        `write compiled file at ${urlToFileSystemPath(compiledFileUrl)}`,
-      )
-      promises.push(
-        writeFileContent(compiledFileUrl, compiledSource, {
-          fileLikelyNotFound: isNew,
-        }).then(() => {
-          const mtime = compileResult.compiledMtime
-          // when compileResult.compiledMtime do not exists it means
-          // the client is not interested in it so
-          // -> moment we write the file is not important
-          // -> There is no need to update mtime
-          if (mtime) {
-            utimesSync(
-              urlToFileSystemPath(compiledFileUrl),
-              new Date(mtime),
-              new Date(mtime),
-            )
-          }
-        }),
-      )
-    }
-
-    if (writeAssetsFile) {
-      promises.push(
-        ...assets.map((assetFileUrl, index) => {
-          logger.debug(
-            `write compiled file asset at ${urlToFileSystemPath(assetFileUrl)}`,
-          )
-          return writeFileContent(assetFileUrl, assetsContent[index], {
-            fileLikelyNotFound: isNew,
-          })
-        }),
-      )
-    }
+    sourcesToRemove.forEach((url) => {
+      const sourceIndex = sources.indexOf(url)
+      if (sourceIndex) {
+        sources.splice(sourceIndex, 1)
+        sourcesContent.splice(sourceIndex, 1)
+      }
+    })
   }
-
-  const metaJsonFileUrl = getMetaJsonFileUrl(compiledFileUrl)
-
-  if (isNew || isUpdated) {
-    let latestMeta
-
-    const sourceAndAssetProps = {
-      sources: sources.map((source) =>
-        urlToRelativeUrl(source, metaJsonFileUrl),
-      ),
-      sourcesEtag: sourcesContent.map((sourceContent) =>
-        bufferToEtag(Buffer.from(sourceContent)),
-      ),
-      assets: assets.map((asset) => urlToRelativeUrl(asset, metaJsonFileUrl)),
-      assetsEtag: assetsContent.map((assetContent) =>
-        bufferToEtag(Buffer.from(assetContent)),
-      ),
-      dependencies: dependencies.filter((dep) => {
-        return !dep.startsWith("data:")
-      }),
-    }
-
-    if (isNew) {
-      latestMeta = {
-        contentType,
-        ...sourceAndAssetProps,
-        createdMs: Number(Date.now()),
-        lastModifiedMs: Number(Date.now()),
-      }
-    } else if (isUpdated) {
-      latestMeta = {
-        ...meta,
-        ...sourceAndAssetProps,
-        lastModifiedMs: Number(Date.now()),
-      }
-    } else {
-      latestMeta = {
-        ...meta,
-      }
-    }
-
+  const { writeCompiledSourceFile = true, writeAssetsFile = true } =
+    compileResult
+  if (writeCompiledSourceFile) {
     logger.debug(
-      `write compiled file meta at ${urlToFileSystemPath(metaJsonFileUrl)}`,
+      `write compiled file at ${urlToFileSystemPath(compiledFileUrl)}`,
     )
     promises.push(
-      writeFileContent(
-        metaJsonFileUrl,
-        JSON.stringify(latestMeta, null, "  "),
-        {
-          fileLikelyNotFound: isNew,
-        },
-      ),
+      writeFileContent(compiledFileUrl, compiledSource, {
+        fileLikelyNotFound: isNew,
+      }).then(() => {
+        const mtime = compileResult.compiledMtime
+        // when compileResult.compiledMtime do not exists it means
+        // the client is not interested in it so
+        // -> moment we write the file is not important
+        // -> There is no need to update mtime
+        if (mtime) {
+          utimesSync(
+            urlToFileSystemPath(compiledFileUrl),
+            new Date(mtime),
+            new Date(mtime),
+          )
+        }
+      }),
     )
   }
-
-  return Promise.all(promises)
+  if (writeAssetsFile) {
+    promises.push(
+      ...assets.map((assetFileUrl, index) => {
+        logger.debug(
+          `write compiled file asset at ${urlToFileSystemPath(assetFileUrl)}`,
+        )
+        return writeFileContent(assetFileUrl, assetsContent[index], {
+          fileLikelyNotFound: isNew,
+        })
+      }),
+    )
+  }
+  const metaJsonFileUrl = getMetaJsonFileUrl(compiledFileUrl)
+  let latestMeta
+  const sourceAndAssetProps = {
+    sources: sources.map((source) => urlToRelativeUrl(source, metaJsonFileUrl)),
+    sourcesEtag: sourcesContent.map((sourceContent) =>
+      bufferToEtag(Buffer.from(sourceContent)),
+    ),
+    assets: assets.map((asset) => urlToRelativeUrl(asset, metaJsonFileUrl)),
+    assetsEtag: assetsContent.map((assetContent) =>
+      bufferToEtag(Buffer.from(assetContent)),
+    ),
+    dependencies: dependencies.filter((dep) => {
+      return !dep.startsWith("data:")
+    }),
+  }
+  if (isNew) {
+    latestMeta = {
+      contentType,
+      ...sourceAndAssetProps,
+      createdMs: Number(Date.now()),
+      lastModifiedMs: Number(Date.now()),
+    }
+  } else if (isUpdated) {
+    latestMeta = {
+      ...meta,
+      ...sourceAndAssetProps,
+      lastModifiedMs: Number(Date.now()),
+    }
+  }
+  logger.debug(
+    `write compiled file meta at ${urlToFileSystemPath(metaJsonFileUrl)}`,
+  )
+  promises.push(
+    writeFileContent(metaJsonFileUrl, JSON.stringify(latestMeta, null, "  "), {
+      fileLikelyNotFound: isNew,
+    }),
+  )
+  promises.push(jsenvDirectory.compiledFileWriteSignal.onwrite())
+  await Promise.all(promises)
 }

--- a/test/error_syntax/error_syntax_launch_browser.test.js
+++ b/test/error_syntax/error_syntax_launch_browser.test.js
@@ -51,7 +51,7 @@ await launchBrowsers(
       collectCompileServerInfo: true,
       ignoreError: true,
     })
-    const jsCompiledUrl = `${jsenvCoreDirectoryUrl}${jsenvDirectoryRelativeUrl}out/${jsRelativeUrl}`
+    const jsCompiledUrl = `${jsenvCoreDirectoryUrl}${jsenvDirectoryRelativeUrl}out_system/${jsRelativeUrl}`
     if (browserRuntime === chromiumRuntime) {
       const actual = {
         status,

--- a/test/error_syntax/error_syntax_launch_node.test.js
+++ b/test/error_syntax/error_syntax_launch_node.test.js
@@ -59,7 +59,7 @@ const test = async ({ runtimeParams } = {}) => {
       forceCompilation: true,
     },
   })
-  const compiledFileUrl = `${jsenvCoreDirectoryUrl}${jsenvDirectoryRelativeUrl}out/${fileRelativeUrl}`
+  const compiledFileUrl = `${jsenvCoreDirectoryUrl}${jsenvDirectoryRelativeUrl}out_system/${fileRelativeUrl}`
   const actual = {
     status,
     error,

--- a/test/file_not_found/import_not_found/import_not_found_launch_browser.test.js
+++ b/test/file_not_found/import_not_found/import_not_found_launch_browser.test.js
@@ -68,7 +68,7 @@ await launchBrowsers(
       return
     }
 
-    const importedFileUrl = `${jsenvCoreDirectoryUrl}${jsenvDirectoryRelativeUrl}out/${importedFileRelativeUrl}`
+    const importedFileUrl = `${jsenvCoreDirectoryUrl}${jsenvDirectoryRelativeUrl}out_system/${importedFileRelativeUrl}`
     const actual = {
       status,
       errorName: error.name,

--- a/test/import_meta_url/import_meta_url_launch_browser.test.js
+++ b/test/import_meta_url/import_meta_url_launch_browser.test.js
@@ -55,7 +55,7 @@ await launchBrowsers(
             urlString:
               browserRuntime === chromiumRuntime
                 ? `${compileServerOrigin}/${fileRelativeUrl}`
-                : `${compileServerOrigin}/${jsenvDirectoryRelativeUrl}out/${fileRelativeUrl}`,
+                : `${compileServerOrigin}/${jsenvDirectoryRelativeUrl}out_system/${fileRelativeUrl}`,
           },
         },
       },

--- a/test/import_meta_url/import_meta_url_launch_node.test.js
+++ b/test/import_meta_url/import_meta_url_launch_node.test.js
@@ -65,7 +65,7 @@ const test = async ({ babelPluginMap, runtimeParams } = {}) => {
     namespace: {
       isInstanceOfUrl: false,
       // still the compiled file because systemjs is needed
-      urlString: `${testDirectoryUrl}.jsenv/out/${fileRelativeUrl}`,
+      urlString: `${testDirectoryUrl}.jsenv/out_system/${fileRelativeUrl}`,
     },
   }
   assert({ actual, expected })
@@ -91,7 +91,7 @@ const test = async ({ babelPluginMap, runtimeParams } = {}) => {
     status: "completed",
     namespace: {
       isInstanceOfUrl: false,
-      urlString: `${testDirectoryUrl}.jsenv/out/${fileRelativeUrl}`,
+      urlString: `${testDirectoryUrl}.jsenv/out_system/${fileRelativeUrl}`,
     },
   }
   assert({ actual, expected })

--- a/test/importing_css/css_with_import_assertion/css_with_import_assertion_launch_browser.test.js
+++ b/test/importing_css/css_with_import_assertion/css_with_import_assertion_launch_browser.test.js
@@ -47,7 +47,7 @@ await launchBrowsers(
     const backgroundUrl =
       browserRuntime === chromiumRuntime
         ? `${compileServerOrigin}/${imgRelativeUrl}`
-        : `${compileServerOrigin}/${jsenvDirectoryRelativeUrl}out/${imgRelativeUrl}`
+        : `${compileServerOrigin}/${jsenvDirectoryRelativeUrl}out_system/${imgRelativeUrl}`
 
     const actual = {
       status,

--- a/test/test_plan/test_plan_node_compile/test_plan_node_compile.test.js
+++ b/test/test_plan/test_plan_node_compile/test_plan_node_compile.test.js
@@ -20,7 +20,7 @@ const testPlan = {
     },
   },
 }
-const depFileCompiledUrl = `${testDirectoryUrl}.jsenv/out/${testDirectoryRelativeUrl}dep.js`
+const depFileCompiledUrl = `${testDirectoryUrl}.jsenv/out_system/${testDirectoryRelativeUrl}dep.js`
 
 const { testPlanSummary, testPlanReport } = await executeTestPlan({
   ...EXECUTE_TEST_PLAN_TEST_PARAMS,


### PR DESCRIPTION
- Ensure compileId are predictible (avoid "out" becoming something different if generated first by build for instance)
  - Use "out_system" when systemjs is part of compilation profile
  - Use "out_build" when compilation profile is for building project
- Wait for a file to be written inside ".jsenv/" before writing `__jsenv_meta__.json`
  - This way .jsenv directory is created only if compilation is required 
