### PR TITLE
add `application/yaml` as textual mime type

### DIFF
--- a/packages/independent/universal/utils/src/content_type/media_type_infos.js
+++ b/packages/independent/universal/utils/src/content_type/media_type_infos.js
@@ -22,6 +22,10 @@ export const mediaTypeInfos = {
   "application/x-gzip": {
     extensions: ["gz"],
   },
+  "application/yaml": {
+    extensions: ["yml", "yaml"],
+    isTextual: true,
+  },
   "application/wasm": {
     extensions: ["wasm"],
   },


### PR DESCRIPTION
YAML was missing and apparently, it recently got an official mime type: https://httptoolkit.com/blog/yaml-media-type-rfc/